### PR TITLE
fix: keep games drawn by multiple corporations from overriding each other

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,17 @@
 services:
   server:
     image: jiseeeh/pcso-lotto-api:latest
+    build: .
     env_file:
       - .env
-    expose:
-      - 9000
+    ports:
+      - 9000:9000
+    # ? some ISPs hijack lottopcso.com's DNS and answer with a block page,
+    # ? whose self-signed cert node rejects with UNABLE_TO_VERIFY_LEAF_SIGNATURE
+    # ill try in prod if this is still an issue, but for now ill comment this
+    # dns:
+    #   - 1.1.1.1
+    #   - 8.8.8.8
     depends_on:
       - redis
     restart: always

--- a/src/api/results/_constants.ts
+++ b/src/api/results/_constants.ts
@@ -53,6 +53,14 @@ export const CORPORATIONS = [
   Corporation.OLD_LAPU_LAPU_CITY,
 ];
 
+// ? used to tell apart games that are drawn by more than one corporation
+// ? on the same date, e.g. "STL Swer3 (Lapu-Lapu City)"
+export const CORPORATION_LABELS: Record<Corporation, string> = {
+  [Corporation.LAPU_LAPU_CITY]: "Lapu-Lapu City",
+  [Corporation.OLD_LAPU_LAPU_CITY]: "Lapu-Lapu City",
+  [Corporation.MANDAUE_CITY]: "Mandaue City",
+};
+
 export const DESCRIPTION_KEYS = [
   GameKeys.WINNING_COMBINATION,
   GameKeys.WINNING_COMBINATION_EXACT,

--- a/src/api/results/_constants.ts
+++ b/src/api/results/_constants.ts
@@ -53,14 +53,6 @@ export const CORPORATIONS = [
   Corporation.OLD_LAPU_LAPU_CITY,
 ];
 
-// ? used to tell apart games that are drawn by more than one corporation
-// ? on the same date, e.g. "STL Swer3 (Lapu-Lapu City)"
-export const CORPORATION_LABELS: Record<Corporation, string> = {
-  [Corporation.LAPU_LAPU_CITY]: "Lapu-Lapu City",
-  [Corporation.OLD_LAPU_LAPU_CITY]: "Lapu-Lapu City",
-  [Corporation.MANDAUE_CITY]: "Mandaue City",
-};
-
 export const DESCRIPTION_KEYS = [
   GameKeys.WINNING_COMBINATION,
   GameKeys.WINNING_COMBINATION_EXACT,

--- a/src/api/v2/results/parse-city.ts
+++ b/src/api/v2/results/parse-city.ts
@@ -1,0 +1,21 @@
+// ? corporation headers look like "MANDAUE CITY (Piona Trading And Supply Corp.)"
+// ? the operator in the parentheses changes over time, so we only rely on the
+// ? city and ignore who is currently running the draw
+const CORPORATION_HEADER = /^(.+?\bCITY)\s*\(.+\)$/i;
+
+const toTitleCase = (value: string) =>
+  value
+    .toLowerCase()
+    .replace(/(^|[\s-])([a-z])/g, (_, separator, letter) => {
+      return `${separator}${letter.toUpperCase()}`;
+    });
+
+// ? returns the city a game was drawn in, or null when the header is not a
+// ? corporation (e.g. a date, or one of the site's non-results tables)
+export const parseCity = (headerValue: string): string | null => {
+  const match = headerValue.trim().match(CORPORATION_HEADER);
+
+  if (!match) return null;
+
+  return toTitleCase(match[1]);
+};

--- a/src/api/v2/results/results-parser.ts
+++ b/src/api/v2/results/results-parser.ts
@@ -2,7 +2,11 @@ import * as cheerio from "cheerio";
 import createHttpError from "http-errors";
 import { logger } from "../../../logger";
 import { redisClient } from "../../lib/redisClient";
-import { CORPORATIONS, GAME_IDS } from "../../results/_constants";
+import {
+  CORPORATION_LABELS,
+  CORPORATIONS,
+  GAME_IDS,
+} from "../../results/_constants";
 import type { Corporation, GameID } from "../../results/results-enum";
 import type {
   ExtractedResults,
@@ -11,6 +15,34 @@ import type {
 import { hasVolatileValues } from "./has-volatile-results";
 import { acquireLock, cacheData, getCachedData } from "./results.cache";
 import { isSameDate, isToday, parseDate } from "./utils/date";
+
+type CollectedGame = {
+  gameId: GameID;
+  corporation: Corporation | null;
+  results: Record<string, string>;
+};
+
+// ? a game can be drawn by more than one corporation on the same date
+// ? (e.g. STL Swer3), so we collect them separately and only suffix the
+// ? corporation's city when the same game id shows up more than once.
+const toResults = (collected: Map<string, CollectedGame>) => {
+  const occurrences = new Map<GameID, number>();
+  for (const { gameId } of collected.values()) {
+    occurrences.set(gameId, (occurrences.get(gameId) ?? 0) + 1);
+  }
+
+  const results: ExtractedResults["results"] = {};
+  for (const game of collected.values()) {
+    const { gameId, corporation } = game;
+    const isDuplicate = (occurrences.get(gameId) ?? 0) > 1;
+    const label = corporation ? CORPORATION_LABELS[corporation] : null;
+    const key = isDuplicate && label ? `${gameId} (${label})` : gameId;
+
+    results[key] = { ...results[key], ...game.results };
+  }
+
+  return results;
+};
 
 export const extractGameResults = async (source: GameResultsSource) => {
   const cachedData = await getCachedData(source.date);
@@ -31,6 +63,7 @@ export const extractGameResults = async (source: GameResultsSource) => {
 
   let lockOwned = false;
   const now = source.date ? parseDate(source.date) : new Date();
+  const collected = new Map<string, CollectedGame>();
 
   try {
     const document = await cheerio.fromURL(source.url);
@@ -71,25 +104,37 @@ export const extractGameResults = async (source: GameResultsSource) => {
         const isValidDateB = !Number.isNaN(dateB.getTime());
 
         let isValidFigure = false;
+        let corporation: Corporation | null = null;
         if (isValidDateB) {
           isValidFigure = GAME_IDS.includes(gameId) && isSameDate(now, dateB);
         } else {
           isValidFigure = CORPORATIONS.includes(headerValue as Corporation);
+          if (isValidFigure) corporation = headerValue as Corporation;
         }
 
         if (!isValidFigure) return;
+
+        // ? keying by corporation too keeps a game drawn by two corporations
+        // ? from overriding itself, since both tables share the same row keys
+        const collectedKey = `${gameId}|${corporation ?? ""}`;
+        const game = collected.get(collectedKey) ?? {
+          gameId,
+          corporation,
+          results: {},
+        };
 
         for (const tableRow of tableBodyChildren) {
           const tableData = document(tableRow).children();
           const key = document(tableData[0]).text();
           const value = document(tableData[1]).text();
 
-          games.results[gameId] = {
-            ...games.results[gameId],
-            [key]: value,
-          };
+          game.results[key] = value;
         }
+
+        collected.set(collectedKey, game);
       });
+
+    games.results = toResults(collected);
 
     if (!hasVolatileValues(games)) {
       await cacheData(games);

--- a/src/api/v2/results/results-parser.ts
+++ b/src/api/v2/results/results-parser.ts
@@ -2,29 +2,26 @@ import * as cheerio from "cheerio";
 import createHttpError from "http-errors";
 import { logger } from "../../../logger";
 import { redisClient } from "../../lib/redisClient";
-import {
-  CORPORATION_LABELS,
-  CORPORATIONS,
-  GAME_IDS,
-} from "../../results/_constants";
-import type { Corporation, GameID } from "../../results/results-enum";
+import { GAME_IDS } from "../../results/_constants";
+import type { GameID } from "../../results/results-enum";
 import type {
   ExtractedResults,
   GameResultsSource,
 } from "../../results/results-types";
 import { hasVolatileValues } from "./has-volatile-results";
+import { parseCity } from "./parse-city";
 import { acquireLock, cacheData, getCachedData } from "./results.cache";
 import { isSameDate, isToday, parseDate } from "./utils/date";
 
 type CollectedGame = {
   gameId: GameID;
-  corporation: Corporation | null;
+  city: string | null;
   results: Record<string, string>;
 };
 
-// ? a game can be drawn by more than one corporation on the same date
-// ? (e.g. STL Swer3), so we collect them separately and only suffix the
-// ? corporation's city when the same game id shows up more than once.
+// ? a game can be drawn in more than one city on the same date (e.g. STL
+// ? Swer3), so we collect them separately and only suffix the city when the
+// ? same game id shows up more than once.
 const toResults = (collected: Map<string, CollectedGame>) => {
   const occurrences = new Map<GameID, number>();
   for (const { gameId } of collected.values()) {
@@ -33,10 +30,9 @@ const toResults = (collected: Map<string, CollectedGame>) => {
 
   const results: ExtractedResults["results"] = {};
   for (const game of collected.values()) {
-    const { gameId, corporation } = game;
+    const { gameId, city } = game;
     const isDuplicate = (occurrences.get(gameId) ?? 0) > 1;
-    const label = corporation ? CORPORATION_LABELS[corporation] : null;
-    const key = isDuplicate && label ? `${gameId} (${label})` : gameId;
+    const key = isDuplicate && city ? `${gameId} (${city})` : gameId;
 
     results[key] = { ...results[key], ...game.results };
   }
@@ -103,23 +99,23 @@ export const extractGameResults = async (source: GameResultsSource) => {
         const dateB = new Date(headerValue);
         const isValidDateB = !Number.isNaN(dateB.getTime());
 
+        const city = isValidDateB ? null : parseCity(headerValue);
+
         let isValidFigure = false;
-        let corporation: Corporation | null = null;
         if (isValidDateB) {
           isValidFigure = GAME_IDS.includes(gameId) && isSameDate(now, dateB);
         } else {
-          isValidFigure = CORPORATIONS.includes(headerValue as Corporation);
-          if (isValidFigure) corporation = headerValue as Corporation;
+          isValidFigure = GAME_IDS.includes(gameId) && city !== null;
         }
 
         if (!isValidFigure) return;
 
-        // ? keying by corporation too keeps a game drawn by two corporations
-        // ? from overriding itself, since both tables share the same row keys
-        const collectedKey = `${gameId}|${corporation ?? ""}`;
+        // ? keying by city too keeps a game drawn in two cities from
+        // ? overriding itself, since both tables share the same row keys
+        const collectedKey = `${gameId}|${city ?? ""}`;
         const game = collected.get(collectedKey) ?? {
           gameId,
-          corporation,
+          city,
           results: {},
         };
 


### PR DESCRIPTION
STL Swer3 is drawn by both Lapu-Lapu City and Mandaue City corporations on the same date. Both tables share the same game id and the same row keys (draw times), so writing them into games.results[gameId] meant the last table won and only one set of results was returned.

Results are now collected per game id + corporation, and the corporation's city is appended to the key only when the same game id appears more than once, so single-draw games keep their existing key.

Closes: #7